### PR TITLE
Multiple fields cursor, sorting and repo options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 ## [Unreleased]
+### Changed
+- allow to iterate over multiple fields in cursor, e.g. `cursor_field: [:id_1, :id_2]`
+- allow multiple fields in starting cursor, e.g. `after_cursor: %{id_1: id1, id_2: id2}`
+- allow ordering or results, e.g. `order: :desc`
+- pass Ecto options to `Ecto.Repo.all/2`
+- raise errors with friendly message on invalid cursor_field, invalid after_cursor and invalid custom select in Ecto query
 
 ## [1.1.0] - 2024-05-16
 ### Changed

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Only limitation is that you have to supply a _cursor column_ (by passing `opts[:
 ```elixir
 def deps do
   [
-    {:ecto_cursor_based_stream, "~> 1.0.2"}
+    {:ecto_cursor_based_stream, "~> 1.1.0"}
   ]
 end
 ```
@@ -48,7 +48,7 @@ Post
 
 ## Useful links
 
-- [Documentation](https://hexdocs.pm/ecto_cursor_based_stream)
+- [Documentation](https://hexdocs.pm/ecto_cursor_based_stream/EctoCursorBasedStream.html)
 - [Examples](https://github.com/allegro/ecto-cursor-based-stream/blob/main/test/ecto_cursor_based_stream_test.exs)
 
 ## Contributing

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 import Config
 
-config :logger, level: :warn
+config :logger, level: :warning
 
 config :ecto_cursor_based_stream, ecto_repos: [TestApp.Repo]
 

--- a/lib/ecto_cursor_based_stream.ex
+++ b/lib/ecto_cursor_based_stream.ex
@@ -36,13 +36,14 @@ defmodule EctoCursorBasedStream do
 
   ## Options
 
-  * `:cursor_field` - the field by which all rows should be iterated.
+  * `:cursor_field` - the field or list of fields by which all rows should be iterated.
 
     **This field must have unique values. (Otherwise, some rows may get skipped.)**
 
     For performance reasons, we recommend that you have an index on that field. Defaults to `:id`.
 
-  * `:after_cursor` - the value of the `:cursor_field` must be greater than it.
+  * `:after_cursor` - the value of the `:cursor_field` that results start. When `:cursor_field` is a list
+    then`:after_cursor` must be a map where keys are cursor fields.
 
     Useful when you want to continue streaming from a certain point.
     Any rows with value equal or smaller than this value will not be included.
@@ -57,10 +58,36 @@ defmodule EctoCursorBasedStream do
 
     Defaults to `:asc`.
 
-  ## Example
+  ## Examples
 
       MyUser
-      |> MyRepo.cursor_based_stream(max_rows: 100)
+      |> MyRepo.cursor_based_stream(max_rows: 1000)
+      |> Stream.each(...)
+      |> Stream.run()
+
+      # change order
+      MyUser
+      |> MyRepo.cursor_based_stream(order: :desc)
+      |> Stream.each(...)
+      |> Stream.run()
+
+      # change cursor field and set starting cursor
+      MyUser
+      |> MyRepo.cursor_based_stream(cursor_field: :email, after_cursor: "foo@bar.com")
+      |> Stream.each(...)
+      |> Stream.run()
+
+      # with multiple fields
+      MyUser
+      |> MyRepo.cursor_based_stream(cursor_field: [:email, :date_of_birth], after_cursor: %{email: "foo@bar.com"})
+      |> Stream.each(...)
+      |> Stream.run()
+
+      # select custom fields
+      # remember to add `cursor_field`!
+      MyUser
+      |> select([u], map(u, [:id, ...])
+      |> MyRepo.cursor_based_stream()
       |> Stream.each(...)
       |> Stream.run()
   """
@@ -80,7 +107,7 @@ defmodule EctoCursorBasedStream do
   @doc false
   @spec call(Ecto.Repo.t(), Ecto.Queryable.t(), cursor_based_stream_opts) :: Enumerable.t()
   def call(repo, queryable, options \\ []) do
-    %{after_cursor: after_cursor, cursor_field: cursor_field} = options = parse_options(options)
+    %{after_cursor: after_cursor, cursor_fields: cursor_fields} = options = parse_options(options)
 
     Stream.unfold(after_cursor, fn cursor ->
       case get_rows(repo, queryable, cursor, options) do
@@ -88,7 +115,7 @@ defmodule EctoCursorBasedStream do
           nil
 
         rows ->
-          next_cursor = get_last_row_cursor(rows, cursor_field)
+          next_cursor = get_last_row_cursor(rows, cursor_fields)
           {rows, next_cursor}
       end
     end)
@@ -97,40 +124,110 @@ defmodule EctoCursorBasedStream do
 
   defp parse_options(options) do
     max_rows = Keyword.get(options, :max_rows, 500)
-    after_cursor = Keyword.get(options, :after_cursor)
+    after_cursor = Keyword.get(options, :after_cursor, nil)
     cursor_field = Keyword.get(options, :cursor_field, :id)
     order = Keyword.get(options, :order, :asc)
 
+    cursor_fields = validate_cursor_fields(cursor_field)
+
     %{
       max_rows: max_rows,
-      after_cursor: after_cursor,
-      cursor_field: cursor_field,
+      cursor_fields: cursor_fields,
+      after_cursor: validate_initial_cursor(cursor_fields, after_cursor),
       order: order
     }
   end
 
+  defp validate_cursor_fields(value) do
+    cursor_fields = List.wrap(value)
+
+    if Enum.all?(cursor_fields, &is_atom/1) do
+      cursor_fields
+    else
+      raise ArgumentError,
+            "EctoCursorBasedStream expected `cursor_field` to be an atom or list of atoms, got: #{inspect(value)}."
+    end
+  end
+
+  defp validate_initial_cursor(_, nil) do
+    nil
+  end
+
+  defp validate_initial_cursor(cursor_fields, %{} = after_cursor) do
+    {after_cursor, rest} = Map.split(after_cursor, cursor_fields)
+
+    if map_size(rest) == 0 do
+      after_cursor
+    else
+      raise ArgumentError,
+            "EctoCursorBasedStream expected `after_cursor` to be a map with fields #{inspect(cursor_fields)}, got: #{inspect(rest)}."
+    end
+  end
+
+  defp validate_initial_cursor([cursor_field], after_cursor) when not is_list(after_cursor) do
+    %{cursor_field => after_cursor}
+  end
+
+  defp validate_initial_cursor(cursor_fields, after_cursor) do
+    raise ArgumentError,
+          "EctoCursorBasedStream expected `after_cursor` to be a map with fields #{inspect(cursor_fields)}, got: #{inspect(after_cursor)}."
+  end
+
   defp get_rows(repo, query, cursor, options) do
-    %{cursor_field: cursor_field, order: order, max_rows: max_rows} = options
+    %{cursor_fields: cursor_fields, order: order, max_rows: max_rows} = options
+    order_by = Enum.map(cursor_fields, fn cursor_field -> {order, cursor_field} end)
 
     query
-    |> order_by([o], ^[{order, cursor_field}])
+    |> order_by([o], ^order_by)
     |> then(fn query ->
-      cond do
-        is_nil(cursor) ->
-          query
-
-        order == :desc ->
-          where(query, [r], field(r, ^cursor_field) < ^cursor)
-
-        true ->
-          where(query, [r], field(r, ^cursor_field) > ^cursor)
-      end
+      apply_cursor(query, cursor_fields, cursor, order)
     end)
     |> limit(^max_rows)
     |> repo.all()
   end
 
-  defp get_last_row_cursor(rows, cursor_field) do
-    rows |> List.last() |> Map.fetch!(cursor_field)
+  defp apply_cursor(query, _cursor_fields, nil, _order) do
+    query
+  end
+
+  defp apply_cursor(query, cursor_fields, cursor, order) do
+    Enum.reduce(cursor_fields, query, fn cursor_field, query ->
+      cursor = Map.get(cursor, cursor_field)
+      apply_cursor_field(query, cursor_field, cursor, order)
+    end)
+  end
+
+  defp apply_cursor_field(query, _cursor_field, nil, _order) do
+    query
+  end
+
+  defp apply_cursor_field(query, cursor_field, cursor, :desc) do
+    where(query, [r], field(r, ^cursor_field) < ^cursor)
+  end
+
+  defp apply_cursor_field(query, cursor_field, cursor, _) do
+    where(query, [r], field(r, ^cursor_field) > ^cursor)
+  end
+
+  defp get_last_row_cursor(rows, cursor_fields) do
+    last_row = List.last(rows)
+
+    unless is_map(last_row) do
+      select = Enum.map_join(cursor_fields, ", ", &inspect/1)
+
+      raise RuntimeError,
+            "EctoCursorBasedStream query must return a map with cursor field. If you are using custom `select` ensure that all cursor fields are returned as a map, e.g. `select([s], map(s, [#{select}]))`."
+    end
+
+    Map.new(cursor_fields, fn cursor_field ->
+      case Map.fetch(last_row, cursor_field) do
+        {:ok, value} ->
+          {cursor_field, value}
+
+        :error ->
+          raise ArgumentError,
+                "EctoCursorBasedStream query did not return cursor field #{inspect(cursor_field)}. If you are using custom `select` ensure that all cursor fields are returned as a map, e.g. `select([s], map(s, [#{inspect(cursor_field)}, ...]))`."
+      end
+    end)
   end
 end

--- a/lib/ecto_cursor_based_stream.ex
+++ b/lib/ecto_cursor_based_stream.ex
@@ -198,18 +198,17 @@ defmodule EctoCursorBasedStream do
 
     query
     |> order_by([o], ^order_by)
-    |> then(fn query ->
-      apply_cursor(query, cursor_fields, cursor, order)
-    end)
+    |> apply_cursor_conditions(cursor_fields, cursor, order)
     |> limit(^max_rows)
     |> repo.all(repo_opts)
   end
 
-  defp apply_cursor(query, _cursor_fields, cursor, _order) when map_size(cursor) == 0 do
+  defp apply_cursor_conditions(query, _cursor_fields, cursor, _order)
+       when map_size(cursor) == 0 do
     query
   end
 
-  defp apply_cursor(query, cursor_fields, cursor, :asc) do
+  defp apply_cursor_conditions(query, cursor_fields, cursor, :asc) do
     conditions =
       cursor_fields
       |> zip_cursor_fields_with_values(cursor)
@@ -225,7 +224,7 @@ defmodule EctoCursorBasedStream do
     where(query, [r], ^conditions)
   end
 
-  defp apply_cursor(query, cursor_fields, cursor, :desc) do
+  defp apply_cursor_conditions(query, cursor_fields, cursor, :desc) do
     conditions =
       cursor_fields
       |> zip_cursor_fields_with_values(cursor)
@@ -269,7 +268,7 @@ defmodule EctoCursorBasedStream do
           {cursor_field, value}
 
         :error ->
-          raise ArgumentError,
+          raise RuntimeError,
                 "EctoCursorBasedStream query did not return cursor field #{inspect(cursor_field)}. If you are using custom `select` ensure that all cursor fields are returned as a map, e.g. `select([s], map(s, [#{inspect(cursor_field)}, ...]))`."
       end
     end)

--- a/priv/repo/migrations/20240801134526_add_fields_to_users.exs
+++ b/priv/repo/migrations/20240801134526_add_fields_to_users.exs
@@ -1,0 +1,10 @@
+defmodule TestApp.Repo.Migrations.AddFieldsToUsers do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add :country_of_birth, :string
+      add :date_of_birth, :utc_datetime_usec
+    end
+  end
+end

--- a/priv/repo/migrations/20240802124348_create_multi_cursor_table.exs
+++ b/priv/repo/migrations/20240802124348_create_multi_cursor_table.exs
@@ -1,0 +1,11 @@
+defmodule TestApp.Repo.Migrations.CreateMultiCursorTable do
+  use Ecto.Migration
+
+  def change do
+    create table(:multi_cursor, primary_key: false) do
+      add :id_1, :integer, primary_key: true
+      add :id_2, :integer, primary_key: true
+      add :id_3, :integer, primary_key: true
+    end
+  end
+end

--- a/test/ecto_cursor_based_stream_test.exs
+++ b/test/ecto_cursor_based_stream_test.exs
@@ -60,5 +60,21 @@ defmodule EctoCursorBasedStreamTest do
 
       assert result == rows |> Enum.slice(1, 2)
     end
+
+    test "if :order option is given, changes order of result", %{rows: rows} do
+      result =
+        User
+        |> Repo.cursor_based_stream(max_rows: 2, order: :asc)
+        |> Enum.to_list()
+
+      assert result == rows
+
+      result =
+        User
+        |> Repo.cursor_based_stream(max_rows: 2, order: :desc)
+        |> Enum.to_list()
+
+      assert result == Enum.reverse(rows)
+    end
   end
 end

--- a/test/ecto_cursor_based_stream_test.exs
+++ b/test/ecto_cursor_based_stream_test.exs
@@ -1,17 +1,39 @@
 defmodule EctoCursorBasedStreamTest do
   use TestApp.RepoCase
 
+  setup do
+    rows = [
+      Repo.insert!(%User{
+        email: "1@test.com",
+        country_of_birth: "POL",
+        date_of_birth: ~U[1990-01-01 00:00:00.000000Z]
+      }),
+      Repo.insert!(%User{
+        email: "2@test.com",
+        country_of_birth: "POL",
+        date_of_birth: ~U[1991-02-02 00:00:00.000000Z]
+      }),
+      Repo.insert!(%User{
+        email: "3@test.com",
+        country_of_birth: "GER",
+        date_of_birth: ~U[1992-03-03 00:00:00.000000Z]
+      }),
+      Repo.insert!(%User{
+        email: "4@test.com",
+        country_of_birth: "GER",
+        date_of_birth: ~U[1993-04-04 00:00:00.000000Z]
+      }),
+      Repo.insert!(%User{
+        email: "5@test.com",
+        country_of_birth: "GBR",
+        date_of_birth: ~U[1994-05-05 00:00:00.000000Z]
+      })
+    ]
+
+    %{rows: rows}
+  end
+
   describe "cursor_based_stream/2" do
-    setup do
-      rows = [
-        Repo.insert!(%User{email: "1@test.com"}),
-        Repo.insert!(%User{email: "2@test.com"}),
-        Repo.insert!(%User{email: "3@test.com"})
-      ]
-
-      %{rows: rows}
-    end
-
     test "if rows total count is smaller than :max_rows option, streams all the rows", %{
       rows: rows
     } do
@@ -45,6 +67,15 @@ defmodule EctoCursorBasedStreamTest do
       assert result == rows
     end
 
+    test "if :cursor_field is a list of fields, iterates rows over all fields", %{rows: rows} do
+      result =
+        User
+        |> Repo.cursor_based_stream(cursor_field: [:country_of_birth, :date_of_birth])
+        |> Enum.to_list()
+
+      assert result == Enum.sort_by(rows, &{&1.country_of_birth, &1.date_of_birth})
+    end
+
     test "if :after_cursor option is given, skips any rows with value not greater than it",
          %{
            rows: rows
@@ -58,7 +89,7 @@ defmodule EctoCursorBasedStreamTest do
         )
         |> Enum.to_list()
 
-      assert result == rows |> Enum.slice(1, 2)
+      assert result == rows |> Enum.slice(1, 4)
     end
 
     test "if :order option is given, changes order of result", %{rows: rows} do
@@ -75,6 +106,134 @@ defmodule EctoCursorBasedStreamTest do
         |> Enum.to_list()
 
       assert result == Enum.reverse(rows)
+    end
+
+    test "sorting on multiple cursor fields", %{rows: rows} do
+      result =
+        User
+        |> Repo.cursor_based_stream(
+          cursor_field: [:country_of_birth, :date_of_birth],
+          order: :asc
+        )
+        |> Enum.to_list()
+
+      assert result == Enum.sort_by(rows, &{&1.country_of_birth, &1.date_of_birth})
+
+      result =
+        User
+        |> Repo.cursor_based_stream(
+          cursor_field: [:country_of_birth, :date_of_birth],
+          order: :desc
+        )
+        |> Enum.to_list()
+
+      assert result ==
+               Enum.sort_by(rows, &{&1.country_of_birth, &1.date_of_birth}) |> Enum.reverse()
+    end
+
+    test "sorting on multiple cursor fields with initial cursor", %{rows: rows} do
+      result =
+        User
+        |> Repo.cursor_based_stream(
+          cursor_field: [:country_of_birth, :date_of_birth],
+          after_cursor: %{country_of_birth: "GBR"}
+        )
+        |> Enum.to_list()
+
+      assert result ==
+               rows |> Enum.sort_by(&{&1.country_of_birth, &1.date_of_birth}) |> Enum.slice(1, 4)
+
+      result =
+        User
+        |> Repo.cursor_based_stream(
+          cursor_field: [:country_of_birth, :date_of_birth],
+          after_cursor: %{country_of_birth: "POL"},
+          order: :desc
+        )
+        |> Enum.to_list()
+
+      assert result ==
+               rows
+               |> Enum.sort_by(&{&1.country_of_birth, &1.date_of_birth}, :desc)
+               |> Enum.slice(2, 3)
+    end
+  end
+
+  describe "validations" do
+    test ":cursor_field must be an atom or list of atoms" do
+      assert_raise ArgumentError,
+                   "EctoCursorBasedStream expected `cursor_field` to be an atom or list of atoms, got: %{}.",
+                   fn ->
+                     User
+                     |> Repo.cursor_based_stream(cursor_field: %{})
+                     |> Enum.to_list()
+                   end
+
+      assert_raise ArgumentError,
+                   "EctoCursorBasedStream expected `cursor_field` to be an atom or list of atoms, got: \"email\".",
+                   fn ->
+                     User
+                     |> Repo.cursor_based_stream(cursor_field: "email")
+                     |> Enum.to_list()
+                   end
+
+      assert_raise ArgumentError,
+                   "EctoCursorBasedStream expected `cursor_field` to be an atom or list of atoms, got: [:id, \"email\"].",
+                   fn ->
+                     User
+                     |> Repo.cursor_based_stream(cursor_field: [:id, "email"])
+                     |> Enum.to_list()
+                   end
+    end
+
+    test ":after_cursor must contain fields from `cursor_field`" do
+      assert_raise ArgumentError,
+                   "EctoCursorBasedStream expected `after_cursor` to be a map with fields [:id, :email], got: \"10\".",
+                   fn ->
+                     User
+                     |> Repo.cursor_based_stream(cursor_field: [:id, :email], after_cursor: "10")
+                     |> Enum.to_list()
+                   end
+
+      assert_raise ArgumentError,
+                   "EctoCursorBasedStream expected `after_cursor` to be a map with fields [:id, :email], got: %{emial: \"foo@bar.com\"}.",
+                   fn ->
+                     User
+                     |> Repo.cursor_based_stream(
+                       cursor_field: [:id, :email],
+                       after_cursor: %{emial: "foo@bar.com"}
+                     )
+                     |> Enum.to_list()
+                   end
+    end
+
+    test "query must `select` cursor fields" do
+      assert_raise RuntimeError,
+                   "EctoCursorBasedStream query must return a map with cursor field. If you are using custom `select` ensure that all cursor fields are returned as a map, e.g. `select([s], map(s, [:id]))`.",
+                   fn ->
+                     User
+                     |> select([u], u.id)
+                     |> Repo.cursor_based_stream(cursor_field: :id)
+                     |> Enum.to_list()
+                   end
+
+      assert_raise ArgumentError,
+                   "EctoCursorBasedStream query did not return cursor field :id. If you are using custom `select` ensure that all cursor fields are returned as a map, e.g. `select([s], map(s, [:id, ...]))`.",
+                   fn ->
+                     User
+                     |> select([u], %{email: u.email})
+                     |> Repo.cursor_based_stream(cursor_field: :id)
+                     |> Enum.to_list()
+                   end
+
+      assert_raise ArgumentError,
+                   "EctoCursorBasedStream query did not return cursor field :id. If you are using custom `select` ensure that all cursor fields are returned as a map, e.g. `select([s], map(s, [:id, ...]))`.",
+                   fn ->
+                     User
+                     |> select([u], %{email: u.email})
+                     |> Repo.cursor_based_stream(cursor_field: [:email, :id])
+                     |> Enum.to_list()
+                   end
     end
   end
 end

--- a/test/ecto_cursor_based_stream_test.exs
+++ b/test/ecto_cursor_based_stream_test.exs
@@ -318,7 +318,7 @@ defmodule EctoCursorBasedStreamTest do
                      |> Enum.to_list()
                    end
 
-      assert_raise ArgumentError,
+      assert_raise RuntimeError,
                    "EctoCursorBasedStream query did not return cursor field :id. If you are using custom `select` ensure that all cursor fields are returned as a map, e.g. `select([s], map(s, [:id, ...]))`.",
                    fn ->
                      User
@@ -327,7 +327,7 @@ defmodule EctoCursorBasedStreamTest do
                      |> Enum.to_list()
                    end
 
-      assert_raise ArgumentError,
+      assert_raise RuntimeError,
                    "EctoCursorBasedStream query did not return cursor field :id. If you are using custom `select` ensure that all cursor fields are returned as a map, e.g. `select([s], map(s, [:id, ...]))`.",
                    fn ->
                      User

--- a/test/support/test_app/multi_cursor.ex
+++ b/test/support/test_app/multi_cursor.ex
@@ -1,0 +1,10 @@
+defmodule TestApp.MultiCursor do
+  use Ecto.Schema
+
+  @primary_key false
+  schema "multi_cursor" do
+    field(:id_1, :integer)
+    field(:id_2, :integer)
+    field(:id_3, :integer)
+  end
+end

--- a/test/support/test_app/repo_case.ex
+++ b/test/support/test_app/repo_case.ex
@@ -22,6 +22,7 @@ defmodule TestApp.RepoCase do
       import Ecto.Changeset
       import Ecto.Query
 
+      alias TestApp.MultiCursor
       alias TestApp.Repo
       alias TestApp.User
     end

--- a/test/support/test_app/user.ex
+++ b/test/support/test_app/user.ex
@@ -3,5 +3,7 @@ defmodule TestApp.User do
 
   schema "users" do
     field(:email, :string)
+    field(:country_of_birth, :string)
+    field(:date_of_birth, :utc_datetime_usec)
   end
 end


### PR DESCRIPTION
* Add support for multi columns cursor (#3 #10) - allow to pass `cursor_field: [:column1, :column2]`.
  * for multi cursor `:after_cursor` accepts a map where keys are cursor fields, e.g `after_cursor: %{column1: x, column2: y`.
* Add custom ordering of results (#14) - e.g. `order: :desc`
* Allow to pass Ecto Repo options that are forwarded to `Repo.all/2` - e.g. `timeout: 100_000` is useful if starting with `after_cursor` on large tables.
* Add validations when invalid options are passed
  * `cursor_field` that isn't atom or list of atoms
  * `after_cursor` that contains map keys that aren't present in `cursor_field` (typos)
  * result doesn't contain `cursor_field` (invalid select)