### PR TITLE
Add option to fetch rows in parallel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
 ### Changed
+- add option to fetch records and process them in parallel, `parallel: true`
 - allow to iterate over multiple fields in cursor, e.g. `cursor_field: [:id_1, :id_2]`
 - allow multiple fields in starting cursor, e.g. `after_cursor: %{id_1: id1, id_2: id2}`
 - allow ordering or results, e.g. `order: :desc`

--- a/lib/ecto_cursor_based_stream/task_synchronous.ex
+++ b/lib/ecto_cursor_based_stream/task_synchronous.ex
@@ -1,0 +1,18 @@
+defmodule EctoCursorBasedStream.TaskSynchronous do
+  @moduledoc false
+
+  def async(fun) do
+    result = fun.()
+
+    struct(Task, %{
+      owner: self(),
+      pid: self(),
+      ref: result,
+      mfa: {:erlang, :apply, [fun, []]}
+    })
+  end
+
+  def await(%Task{ref: result}, _timeout \\ 5000) do
+    result
+  end
+end


### PR DESCRIPTION
PR adds option to fetch rows in parallel with `Task` to speed up processing.